### PR TITLE
SearchParameter EqualsAndHash 를 위한 난수변수 추가, Board타입 검색 컨트롤러 단위 테스트

### DIFF
--- a/src/main/java/com/myboard/aop/resolver/SearchParamsArgumentResolver.java
+++ b/src/main/java/com/myboard/aop/resolver/SearchParamsArgumentResolver.java
@@ -33,7 +33,6 @@ public class SearchParamsArgumentResolver implements HandlerMethodArgumentResolv
         while (parameterNames.hasMoreElements()) {
             String name = parameterNames.nextElement();
             parameterMap.put(name, nativeRequest.getParameter(name));
-
         }
 
         return SearchParameter.of(

--- a/src/main/java/com/myboard/controller/search/SearchController.java
+++ b/src/main/java/com/myboard/controller/search/SearchController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +21,7 @@ public class SearchController {
 
     private final SearchService searchService;
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/search")
     public ResponseEntity<SearchResponseDto> search(@SearchParams SearchParameter searchParameter) {
 

--- a/src/main/java/com/myboard/dto/requestDto/search/SearchParameter.java
+++ b/src/main/java/com/myboard/dto/requestDto/search/SearchParameter.java
@@ -2,13 +2,11 @@ package com.myboard.dto.requestDto.search;
 
 import com.myboard.exception.search.InvalidPageSizeException;
 import com.myboard.exception.search.InvalidPageStartException;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.domain.PageRequest;
 
 @Getter
+@EqualsAndHashCode(of = "id")
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SearchParameter {
@@ -17,6 +15,7 @@ public class SearchParameter {
     private static final int MIN_PAGE_SIZE = 20;
     private static final int MAX_PAGE_SIZE = 50;
 
+    private static final double id = Math.random();
     private SearchKeyword searchKeyword;
     private SearchType searchType;
     private int start;

--- a/src/test/java/com/myboard/controller/search/SearchControllerTest.java
+++ b/src/test/java/com/myboard/controller/search/SearchControllerTest.java
@@ -1,10 +1,125 @@
 package com.myboard.controller.search;
 
+import com.myboard.aop.resolver.SearchParamsArgumentResolver;
+import com.myboard.dto.requestDto.search.SearchParameter;
+import com.myboard.dto.responseDto.board.BoardResponseDto;
+import com.myboard.dto.responseDto.search.SearchResponseDto;
+import com.myboard.exception.GlobalControllerAdvice;
+import com.myboard.service.search.SearchService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("검색 컨트롤러 단위 테스트")
 @ExtendWith(MockitoExtension.class)
 public class SearchControllerTest {
+
+    @InjectMocks
+    private SearchController searchController;
+
+    @Mock
+    private SearchService searchService;
+
+    @Mock
+    private SearchParamsArgumentResolver searchParamsArgumentResolver;
+
+    private MockMvc mockMvc;
+
+    private final static String BOARD_KEYWORD = "board";
+    private final static String ARTICLE_KEYWORD = "article";
+    private final static String TYPE_BOARD = "board";
+    private final static String TYPE_ARTICLE = "article";
+    private final static String START = "0";
+    private final static String MIN_SIZE = "20";
+    private final static String MAX_SIZE = "50";
+
+    @BeforeEach
+    public void init() throws Exception {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(searchController)
+                .setControllerAdvice(new GlobalControllerAdvice())
+                .setCustomArgumentResolvers(searchParamsArgumentResolver)
+                .build();
+    }
+
+    private void initSearchParamsArgumentResolverBoardType() throws Exception {
+        // init CurrentUserLoginResolver
+        given(searchParamsArgumentResolver.supportsParameter(any()))
+                .willReturn(true);
+
+        given(searchParamsArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(SearchParameter.of(
+                        BOARD_KEYWORD, TYPE_BOARD, START, MIN_SIZE
+                ));
+    }
+
+    private BoardResponseDto getBoardResponseDto() {
+        return BoardResponseDto.builder()
+                .boardId(1L)
+                .boardName("boardName")
+                .createdDateTime(LocalDateTime.now())
+                .totalArticle(2L)
+                .totalNewArticle(1L)
+                .build();
+    }
+
+    private SearchResponseDto getSearchResponseDto() {
+        SearchResponseDto searchResponseDto = new SearchResponseDto();
+        searchResponseDto.setResult(getBoardResponseDto());
+
+        return searchResponseDto;
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("타입: 게시판 검색 - 성공")
+    void searchBoard() throws Exception {
+        // given
+        SearchResponseDto searchResponse = getSearchResponseDto();
+
+        SearchParameter searchParameter = SearchParameter.of(BOARD_KEYWORD, TYPE_BOARD, START, MIN_SIZE);
+
+        initSearchParamsArgumentResolverBoardType();
+
+        given(searchService.search(searchParameter))
+                .willReturn(searchResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/search")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8")
+                        .param("keyword", BOARD_KEYWORD)
+                        .param("type", TYPE_BOARD)
+                        .param("start", START)
+                        .param("size", MIN_SIZE)
+        );
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.boardId", searchResponse).exists())
+                .andExpect(jsonPath("$.result.boardName", searchResponse).exists())
+                .andExpect(jsonPath("$.result.createdDateTime", searchResponse).exists())
+                .andExpect(jsonPath("$.result.totalArticle", searchResponse).exists())
+                .andExpect(jsonPath("$.result.totalNewArticle", searchResponse).exists())
+        ;
+    }
 }


### PR DESCRIPTION
SearchParameter EqualsAndHash 를 위한 난수변수 추가, Board타입 검색 컨트롤러 단위 테스트

controller 테스트 도중 controller 파라미터가 service단 파라미터와 일치하지 않아 테스트 실패 -> @EqualsAndHash 추가하여 해결